### PR TITLE
fix: type error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ const $a = signal(10);
 
 const $b = computed(() => {
   // `$a` will not trigger updates on `$b`.
-  const value = peek($a);
+  const value = peek(() => $a);
 });
 ```
 


### PR DESCRIPTION
`peek` should be called with a function returning the signal value