### PR TITLE
Fix node.id when computed

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -373,8 +373,8 @@ const ComputeNode = function Computation(
   this._observers = null;
   this._value = initialValue;
 
-  if (__DEV__) this.id = options?.id ?? (this._compute ? 'computed' : 'signal');
   if (compute) this._compute = compute;
+  if (__DEV__) this.id = options?.id ?? (this._compute ? 'computed' : 'signal');
   if (options && options.dirty) this._changed = options.dirty;
 };
 


### PR DESCRIPTION
The order the id determined was incorrect.

It checked this._compute, before it was set.

Let me know if there should be a test (wasn't sure since this only applies to DEV mode)
